### PR TITLE
remove same51.h include

### DIFF
--- a/src/CANSAME5x.cpp
+++ b/src/CANSAME5x.cpp
@@ -9,8 +9,6 @@
 #include "CANSAME5x.h"
 #include "wiring_private.h"
 
-#include "same51.h"
-
 #define DEBUG_CAN (0)
 #if DEBUG_CAN
 #define DEBUG_PRINT(...) (Serial.print(__VA_ARGS__), ((void)0))


### PR DESCRIPTION
after https://github.com/adafruit/ArduinoCore-samd/pull/291, the `same51.h` is included by default `sam.h`. This can be dropped safely. Fix  https://github.com/adafruit/ArduinoCore-samd/issues/297