### PR TITLE
Update ESP32SJA1000.cpp

### DIFF
--- a/src/ESP32SJA1000.cpp
+++ b/src/ESP32SJA1000.cpp
@@ -3,7 +3,7 @@
 
 #ifdef ARDUINO_ARCH_ESP32
 
-#include "esp_intr.h"
+#include "esp_intr_alloc.h"
 #include "soc/dport_reg.h"
 #include "driver/gpio.h"
 


### PR DESCRIPTION
Support for ESP32 library 2.x

Updating to use latest stable interrupt allocation header.

https://github.com/espressif/esp-idf/blob/f8bda32/components/esp32/include/esp_intr_alloc.h