### PR TITLE
adding code from adafruit examples so the Adafruit-M4-CAN-EXPRESS wil…

### DIFF
--- a/examples/CANReceiver/CANReceiver.ino
+++ b/examples/CANReceiver/CANReceiver.ino
@@ -11,12 +11,14 @@ void setup() {
 
   // if using the Adafruit-M4-CAN-EXPRESS as shown in these examples
   // https://learn.adafruit.com/adafruit-feather-m4-can-express/arduino-can-examples
-  // add the following lines
+  // enable the following settings
+  #if defined(ADAFRUIT_FEATHER_M4_CAN)
   pinMode(PIN_CAN_STANDBY, OUTPUT);
   digitalWrite(PIN_CAN_STANDBY, false); // turn off STANDBY
   pinMode(PIN_CAN_BOOSTEN, OUTPUT);
   digitalWrite(PIN_CAN_BOOSTEN, true); // turn on booster
-
+  #endif
+  
   // start the CAN bus at 500 kbps
   if (!CAN.begin(500E3)) {
     Serial.println("Starting CAN failed!");

--- a/examples/CANReceiver/CANReceiver.ino
+++ b/examples/CANReceiver/CANReceiver.ino
@@ -9,6 +9,14 @@ void setup() {
 
   Serial.println("CAN Receiver");
 
+  // if using the Adafruit-M4-CAN-EXPRESS as shown in these examples
+  // https://learn.adafruit.com/adafruit-feather-m4-can-express/arduino-can-examples
+  // add the following lines
+  pinMode(PIN_CAN_STANDBY, OUTPUT);
+  digitalWrite(PIN_CAN_STANDBY, false); // turn off STANDBY
+  pinMode(PIN_CAN_BOOSTEN, OUTPUT);
+  digitalWrite(PIN_CAN_BOOSTEN, true); // turn on booster
+
   // start the CAN bus at 500 kbps
   if (!CAN.begin(500E3)) {
     Serial.println("Starting CAN failed!");

--- a/examples/CANReceiverCallback/CANReceiverCallback.ino
+++ b/examples/CANReceiverCallback/CANReceiverCallback.ino
@@ -11,12 +11,14 @@ void setup() {
 
   // if using the Adafruit-M4-CAN-EXPRESS as show in these examples
   // https://learn.adafruit.com/adafruit-feather-m4-can-express/arduino-can-examples
-  // add the following lines
+  // enable the following settings
+  #if defined(ADAFRUIT_FEATHER_M4_CAN)
   pinMode(PIN_CAN_STANDBY, OUTPUT);
   digitalWrite(PIN_CAN_STANDBY, false); // turn off STANDBY
   pinMode(PIN_CAN_BOOSTEN, OUTPUT);
   digitalWrite(PIN_CAN_BOOSTEN, true); // turn on booster
-
+  #endif
+  
   // start the CAN bus at 500 kbps
   if (!CAN.begin(500E3)) {
     Serial.println("Starting CAN failed!");

--- a/examples/CANReceiverCallback/CANReceiverCallback.ino
+++ b/examples/CANReceiverCallback/CANReceiverCallback.ino
@@ -9,6 +9,14 @@ void setup() {
 
   Serial.println("CAN Receiver Callback");
 
+  // if using the Adafruit-M4-CAN-EXPRESS as show in these examples
+  // https://learn.adafruit.com/adafruit-feather-m4-can-express/arduino-can-examples
+  // add the following lines
+  pinMode(PIN_CAN_STANDBY, OUTPUT);
+  digitalWrite(PIN_CAN_STANDBY, false); // turn off STANDBY
+  pinMode(PIN_CAN_BOOSTEN, OUTPUT);
+  digitalWrite(PIN_CAN_BOOSTEN, true); // turn on booster
+
   // start the CAN bus at 500 kbps
   if (!CAN.begin(500E3)) {
     Serial.println("Starting CAN failed!");

--- a/examples/CANSender/CANSender.ino
+++ b/examples/CANSender/CANSender.ino
@@ -11,11 +11,13 @@ void setup() {
 
   // if using the Adafruit-M4-CAN-EXPRESS as show in these examples
   // https://learn.adafruit.com/adafruit-feather-m4-can-express/arduino-can-examples
-  // add the following lines
+  // enable the following settings
+  #if defined(ADAFRUIT_FEATHER_M4_CAN)
   pinMode(PIN_CAN_STANDBY, OUTPUT);
   digitalWrite(PIN_CAN_STANDBY, false); // turn off STANDBY
   pinMode(PIN_CAN_BOOSTEN, OUTPUT);
   digitalWrite(PIN_CAN_BOOSTEN, true); // turn on booster
+  #endif
 
   // start the CAN bus at 500 kbps
   if (!CAN.begin(500E3)) {

--- a/examples/CANSender/CANSender.ino
+++ b/examples/CANSender/CANSender.ino
@@ -9,6 +9,14 @@ void setup() {
 
   Serial.println("CAN Sender");
 
+  // if using the Adafruit-M4-CAN-EXPRESS as show in these examples
+  // https://learn.adafruit.com/adafruit-feather-m4-can-express/arduino-can-examples
+  // add the following lines
+  pinMode(PIN_CAN_STANDBY, OUTPUT);
+  digitalWrite(PIN_CAN_STANDBY, false); // turn off STANDBY
+  pinMode(PIN_CAN_BOOSTEN, OUTPUT);
+  digitalWrite(PIN_CAN_BOOSTEN, true); // turn on booster
+
   // start the CAN bus at 500 kbps
   if (!CAN.begin(500E3)) {
     Serial.println("Starting CAN failed!");


### PR DESCRIPTION
I used the examples from the Adafruit Fork with the Adafruit M4 CAN Express, but they didn't work. I then realized the the code examples from https://learn.adafruit.com/adafruit-feather-m4-can-express/arduino-can-examples had code that turned on the boost converter, and that with this code the examples worked fine. 

This PR adds code to make sure the chip is not in standby and turns on the boost converter. Since this fork is for the Adafruit feather, I thought it made sense. They are enabled only if the board definition of ADAFRUIT_FEATHER_M4_CAN exists. I could check for the existence of STANDBY and BOOSTEN pins, but this made it clear it was for that board.
